### PR TITLE
Mount boot device using label

### DIFF
--- a/custom-config.fcc
+++ b/custom-config.fcc
@@ -34,15 +34,6 @@ storage:
               done
               echo "${value}"
           }
-          # Get install device
-          device="$(karg coreos.inst.install_dev)"
-          if [[ -z $device ]]; then
-              echo "Install device not specified."
-              exit 1
-          fi
-          # Append /dev/ if missing
-          device="/dev/${device##/dev/}"
-
           # Wait for device nodes
           udevadm settle
           
@@ -53,9 +44,8 @@ storage:
           fi
           export PRIMARY_MAC=$(echo $macs | awk -F, '{print $1}')
           export SECONDARY_MAC=$(echo $macs | awk -F, '{print $2}')
-          mount "$device"1 /var/mnt
-          echo -e "PRIMARY_MAC=${PRIMARY_MAC}\nSECONDARY_MAC=${SECONDARY_MAC}" > /var/mnt/mac_addresses
-          umount /var/mnt
+          mount "/dev/disk/by-label/boot" /boot
+          echo -e "PRIMARY_MAC=${PRIMARY_MAC}\nSECONDARY_MAC=${SECONDARY_MAC}" > /boot/mac_addresses
          
     - path: /usr/local/bin/create-datastore
       mode: 0755


### PR DESCRIPTION
@phoracek @RamLavi 
Mount device use kargs to set the storage location for the mac_address file , 
new command will search for the boot device that is set to save the file, will help in not being depended on new OCP installation location 