### PR TITLE
working around changes in OCP 4.7.x

### DIFF
--- a/mco_ovs_supervisor.yml.tmpl
+++ b/mco_ovs_supervisor.yml.tmpl
@@ -12,9 +12,7 @@ spec:
       units:
         - contents: |
             [Unit]
-            After=network-online.target
-            Wants=network-online.target
-            After=openvswitch.service
+            After=NetworkManager.service openvswitch.service
             [Service]
             Type=oneshot
             ExecStart=/bin/sh /var/setup-ovs.sh

--- a/mco_ovs_workers.yml.tmpl
+++ b/mco_ovs_workers.yml.tmpl
@@ -12,9 +12,7 @@ spec:
       units:
         - contents: |
             [Unit]
-            After=network-online.target
-            Wants=network-online.target
-            After=openvswitch.service
+            After=NetworkManager.service openvswitch.service
             [Service]
             Type=oneshot
             ExecStart=/bin/sh /var/setup-ovs.sh

--- a/setup-ovs.sh
+++ b/setup-ovs.sh
@@ -66,7 +66,6 @@ if [[ $(nmcli conn | grep -c ovs) -eq 0 ]]; then
       nmcli c delete $(nmcli c show |grep ovs-cnv |awk '{print $1}') || true
   else
       nmcli conn mod brcnv-iface connection.autoconnect yes
-      reboot
   fi
 else
     echo "ovs bridge already present"

--- a/setup-ovs.sh
+++ b/setup-ovs.sh
@@ -36,6 +36,9 @@ if [[ $(nmcli conn | grep -c ovs) -eq 0 ]]; then
   echo -e "default dev: $default_device ($profile_name)\nsecondary dev: $secondary_device ($secondary_profile_name)"
   
   mac=$(sudo nmcli -g GENERAL.HWADDR dev show $default_device | sed -e 's/\\//g')
+
+  # delete old bridge if it exists
+  ovs-vsctl --if-exists del-br brcnv
   
   # make bridge
   nmcli conn add type ovs-bridge conn.interface brcnv 802-3-ethernet.cloned-mac-address $mac


### PR DESCRIPTION
Recent changes in OCP/CoreOS cause the OVS config to get lost in between reboots. This change will delete the OvS bridge if it exists before recreating them. This will now happen on every boot.