### PR TITLE
ci, Add ci using coreos ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Change *“ovs-port.bond-mode”* to the desired type and make sure that all oth
 
 - MachineConfig file is a “Day 2” tool that allows to configure or run scripts on a machine with an installed OS (post-installation).
 
+## CI and Testing
+This repo uses [coreos-assembler repo](https://github.com/coreos/coreos-assembler) to run important scenarios relevant to this use-case.
+The test downloads the latest RHCOS image and runs network related tests, using the local `setup-ovs.sh` script.
+You can run these tests manually on Fedora by running the test script:
+```bash
+sudo dnf install -y git go make wget qemu qemu-img swtpm
+./tests/test-coreos.sh
+```
+
 ## Additional Documentation 
  - [Redhat CoreOS (RHCORS) features including ignition and machineConfig explanation](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/architecture/architecture-rhcos)
 

--- a/tests/test-coreos.sh
+++ b/tests/test-coreos.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+set -ex
+
+RHCOS_SLB_REPO_URL=https://github.com/coreos/coreos-assembler.git
+RHCOS_SLB_TEST_PATH=mantle/kola/tests/misc/network.go
+TESTS_LIST=(rhcos.network.multiple-nics rhcos.network.bond-with-dhcp)
+TMP_COREOS_ASSEMBLER_PATH=$(mktemp -d -u -p /tmp -t coreos-assembler-XXXXXX)
+IMAGE_PATH=/tmp/rhcos-latest-image
+SCRIPT_FOLDER=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+RHCOS_SLB_REPO_PATH=${SCRIPT_FOLDER%/*}
+
+create_artifacts_path() {
+  local tmp_dir=$1
+  export ARTIFACTS=${ARTIFACTS-${tmp_dir}/artifacts}
+  mkdir -p ${ARTIFACTS}/_kola_temp
+}
+
+fetch_repo() {
+  local destination=$1
+  local url=$2
+  local commit=$3
+
+  if [ ! -d ${destination} ]; then
+    mkdir -p ${destination}
+    git clone ${url} ${destination}
+  fi
+
+  (
+    cd ${destination}
+    git reset ${commit} --hard
+  )
+}
+
+fetch_latest_rhcos_image() {
+  local image_path=$1
+  local image_url="https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/latest/"
+  local latest_image_gz=$(curl ${image_url} | grep -o rhcos-[0-9].[0-9].[0-9][0-9]-x86_64-qemu.x86_64.qcow2.gz | head -1)
+  if [[ -z "${latest_image_gz}" ]]; then
+    echo failed to get the latest image name. check url and regex
+    exit 1
+  fi
+  local image_name=${latest_image_gz%.gz}
+
+  local shasum=$(curl ${image_url}/sha256sum.txt | grep ${latest_image_gz} | awk '{print $1;}')
+  if [[ -z "${shasum}" ]]; then
+    echo failed to get the latest image shasum. check url and regex
+    exit 1
+  fi
+
+  if [[ $(echo "${shasum} ${image_path}/${latest_image_gz}" | sha256sum --check) != "${image_path}/${latest_image_gz}: OK" ]]; then
+    mkdir -p ${image_path}
+    rm -rf ${image_path}/*
+    wget -O ${image_path}/${latest_image_gz} ${image_url}/${latest_image_gz}
+  fi
+
+  gzip -dk --force ${image_path}/${latest_image_gz}
+  echo ${image_path}/${image_name}
+}
+
+replace_setup_ovs_script() {
+  local rhcos_slb_repo_path=$1
+  local coreos_ci_repo_path=$2
+  local coreos_ci_test_relative_path=$3
+  local setup_ovs_script=${coreos_ci_repo_path}/setup-ovs.sh
+  local coreos_ci_full_path=${coreos_ci_repo_path}/${coreos_ci_test_relative_path}
+
+  # Copy setup_ovs script from rhcos_slb_repo to the coreos-ci repo
+  cp ${rhcos_slb_repo_path}/setup-ovs.sh ${setup_ovs_script}
+  # We need to do specific changes to the script in order for it to run on the coreos-ci
+  # Remove the exit fail if macs file in not inplace.
+  sed -i 's|exit 1|exit 0|g' ${setup_ovs_script}
+
+  # Rename the current script variable in coreos-assemlber
+  sed -i 's|setupOvsScript =|notUsedSetupOvsScript =|g' ${coreos_ci_full_path}
+  # Add the new script to the coreos-ci instead of the old variable
+  local new_ovs_script="$(cat ${setup_ovs_script})"
+  echo "var setupOvsScript =\`${new_ovs_script}\`" >> ${coreos_ci_full_path}
+}
+
+run_tests() {
+  local latest_image=$1
+
+  cd mantle && make >/dev/null
+  for test_name in "${TESTS_LIST[@]}"; do
+    test_output=${TMP_COREOS_ASSEMBLER_PATH}/${test_name}_output
+    ./bin/kola run -b rhcos --qemu-image ${latest_image} ${test_name} >${test_output}
+    if [[ ! $(grep "PASS: ${test_name}" ${test_output}) ]]; then
+      tests_failed=${test_name},${tests_failed}
+    fi
+    cp ${test_output} ${ARTIFACTS} || true
+  done
+
+  echo "${tests_failed}"
+}
+
+teardown() {
+	echo "Copying test artifacts to ${ARTIFACTS}"
+  cp -r ${TMP_COREOS_ASSEMBLER_PATH}/mantle/_kola_temp/* ${ARTIFACTS}/_kola_temp || true
+}
+
+fetch_repo ${TMP_COREOS_ASSEMBLER_PATH} ${RHCOS_SLB_REPO_URL} main
+cd ${TMP_COREOS_ASSEMBLER_PATH}
+
+create_artifacts_path ${TMP_COREOS_ASSEMBLER_PATH}
+trap teardown EXIT SIGINT SIGTERM
+
+latest_image=$(fetch_latest_rhcos_image ${IMAGE_PATH})
+
+replace_setup_ovs_script ${RHCOS_SLB_REPO_PATH} ${TMP_COREOS_ASSEMBLER_PATH} mantle/kola/tests/misc/network.go
+
+tests_failed=$(run_tests ${latest_image})
+
+if [[ ! -z ${tests_failed} ]]; then
+  echo "tests failed: ${tests_failed}"
+  exit 1
+else
+  echo "tests passed"
+fi


### PR DESCRIPTION
Adding a new test script that will run related coreos ci tests
with the current set-ovs.sh script
Running this before each PR will help us achive better
resiliance and ci repo integrity

Signed-off-by: Ram Lavi <ralavi@redhat.com>