### PR TITLE
ci, Add junit.xml

### DIFF
--- a/tests/test-coreos.sh
+++ b/tests/test-coreos.sh
@@ -13,7 +13,7 @@ RHCOS_SLB_REPO_PATH=${SCRIPT_FOLDER%/*}
 create_artifacts_path() {
   local tmp_dir=$1
   export ARTIFACTS=${ARTIFACTS-${tmp_dir}/artifacts}
-  mkdir -p ${ARTIFACTS}/_kola_temp
+  mkdir -p ${ARTIFACTS}
 }
 
 fetch_repo() {
@@ -78,6 +78,20 @@ replace_setup_ovs_script() {
   echo "var setupOvsScript =\`${new_ovs_script}\`" >> ${coreos_ci_full_path}
 }
 
+print_test_results() {
+  local test_output=$1
+  cat ${test_output}
+}
+
+expect_tests_to_succeed() {
+  local test_output=$1
+  if [[ $(grep "FAIL:" ${test_output} >/dev/null) ]]; then
+    exit 1
+  else
+    echo "tests passed"
+  fi
+}
+
 run_tests() {
   local latest_image=$1
   local test_output=$2
@@ -91,11 +105,15 @@ run_test_suite() {
   test_output=${TMP_COREOS_ASSEMBLER_PATH}/tests_output
   run_tests ${latest_image} ${test_output}
 
+
+  print_test_results ${test_output}
+
+  expect_tests_to_succeed ${test_output}
 }
 
 teardown() {
-	echo "Copying test artifacts to ${ARTIFACTS}"
-  cp -r ${TMP_COREOS_ASSEMBLER_PATH}/mantle/_kola_temp/* ${ARTIFACTS}/_kola_temp || true
+  echo "Copying test artifacts to ${ARTIFACTS}"
+  cp -r ${TMP_COREOS_ASSEMBLER_PATH}/mantle/_kola_temp/* ${ARTIFACTS} || true
 }
 
 fetch_repo ${TMP_COREOS_ASSEMBLER_PATH} ${RHCOS_SLB_REPO_URL} main

--- a/tests/test-coreos.sh
+++ b/tests/test-coreos.sh
@@ -78,6 +78,11 @@ replace_setup_ovs_script() {
   echo "var setupOvsScript =\`${new_ovs_script}\`" >> ${coreos_ci_full_path}
 }
 
+generate_junit_from_tap_file() {
+  local output_path_relative_to_mantle=$1
+  npx tap-junit --pretty -i ${output_path_relative_to_mantle}/test.tap -o _kola_temp -n "junit.xml" || true
+}
+
 print_test_results() {
   local test_output=$1
   cat ${test_output}
@@ -105,6 +110,7 @@ run_test_suite() {
   test_output=${TMP_COREOS_ASSEMBLER_PATH}/tests_output
   run_tests ${latest_image} ${test_output}
 
+  generate_junit_from_tap_file "$(grep -o '_kola_temp/[[:print:]]*' ${test_output})"
 
   print_test_results ${test_output}
 


### PR DESCRIPTION
This PR performs some refactoring in order to create a junit.xml from the test.tap already created by the coreos-ci