### PR TITLE
capture-macs, Fix /boot mount handling

### DIFF
--- a/custom-config.fcc
+++ b/custom-config.fcc
@@ -39,12 +39,15 @@ storage:
           
           macs="$(karg macAddressList)"
           if [[ -z $macs ]]; then
-            echo "No MAC addresses specified."
-            exit 1
+              echo "No MAC addresses specified."
+              exit 1
           fi
           export PRIMARY_MAC=$(echo $macs | awk -F, '{print $1}')
           export SECONDARY_MAC=$(echo $macs | awk -F, '{print $2}')
-          mount "/dev/disk/by-label/boot" /boot
+          if [[ $(cat /proc/mounts | awk '{print $2}' | grep "/boot") ]]; then
+              MOUNT_FLAGS="-o rw,remount"
+          fi
+          mount ${MOUNT_FLAGS} "/dev/disk/by-label/boot" /boot
           echo -e "PRIMARY_MAC=${PRIMARY_MAC}\nSECONDARY_MAC=${SECONDARY_MAC}" > /boot/mac_addresses
          
     - path: /usr/local/bin/create-datastore


### PR DESCRIPTION
the mount command in capture-macs script is flaky on
RHCOS cosa test platform [0], while when using PXE server the
problem does not manifest. The reason is cosa test is faking
things a bit by using a qemu image rather than a real PXE boot.
And in the qemu image, /boot gets mounted very early on,
so this service was racing with that.
In order to allow a more robust capture-macs script, allowing
boot remount should it already been mounted.

[0] https://github.com/coreos/coreos-assembler/issues/2326

Signed-off-by: Ram Lavi <ralavi@redhat.com>