### PR TITLE
tests, Allow the test to continue in fail case

### DIFF
--- a/tests/test-coreos.sh
+++ b/tests/test-coreos.sh
@@ -111,7 +111,7 @@ run_test_suite() {
 
   cd mantle && make >/dev/null
   test_output=${TMP_COREOS_ASSEMBLER_PATH}/tests_output
-  run_tests ${latest_image} ${test_output}
+  run_tests ${latest_image} ${test_output} || true
 
   generate_junit_from_tap_file "$(grep -o '_kola_temp/[[:print:]]*' ${test_output})"
 

--- a/tests/test-coreos.sh
+++ b/tests/test-coreos.sh
@@ -93,7 +93,7 @@ print_test_results() {
 
 expect_tests_to_succeed() {
   local test_output=$1
-  if [[ $(grep "FAIL:" ${test_output} >/dev/null) ]]; then
+  if [[ -n "$(grep "FAIL:" ${test_output})" ]]; then
     exit 1
   else
     echo "tests passed"


### PR DESCRIPTION
Currently when the test fails the scripts stops without printing
the error message. Allow the test to continue allows for a better
log output.

Signed-off-by: Ram Lavi <ralavi@redhat.com>