### PR TITLE
[simplify-networking] ci, Fix fail condition

### DIFF
--- a/tests/test-coreos.sh
+++ b/tests/test-coreos.sh
@@ -93,7 +93,7 @@ print_test_results() {
 
 expect_tests_to_succeed() {
   local test_output=$1
-  if [[ $(grep "FAIL:" ${test_output} >/dev/null) ]]; then
+  if [[ -n "$(grep "FAIL:" ${test_output})" ]]; then
     exit 1
   else
     echo "tests passed"


### PR DESCRIPTION
The grep seems to sometimes miss the failure. Fix to check grep output
explicitly

Signed-off-by: Ram Lavi <ralavi@redhat.com>