### PR TITLE
[simplify-networking] interfaces, Set configure interfaces script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,33 +34,28 @@ export base64_capture_macs_script_content=$(cat capture-macs.sh|base64 -w 0) && 
 fcct custom-config.fcc > file.ign
 ```
 
-  - Upload `file.ign` to a shared location which the OpenShift nodes can access.
+  - Upload `file.ign` to a shared location where the OpenShift nodes can access.
 
-- Base64 encode the `setup-ovs.sh` file and paste the content into each MCO file into "base64_script_content" section. 
+- Base64 encode the `init-interfaces.sh` file and paste the content into each MCO file into "base64_script_content" section. 
 
     **TIP:** To update the content you can use:
 
 ```
-export base64_script_content=$(cat setup-ovs.sh|base64 -w 0) && envsubst <  mco_ovs_workers.yml.tmpl > mco_ovs_workers.yml && envsubst < mco_ovs_supervisor.yml.tmpl > mco_ovs_supervisor.yml
+export base64_script_content=$(cat init-interfaces.sh|base64 -w 0) && envsubst <  mco_ovs_workers.yml.tmpl > mco_ovs_workers.yml && envsubst < mco_ovs_supervisor.yml.tmpl > mco_ovs_supervisor.yml
 ```
-
-- MCO files are MachineConfig, which you can apply manually once the cluster is up or add it to the installation automation/pipeline.
 
 ### 3. Run the installation
 - Follow the guide to install a bare-metal cluster in the [OpenShift production documentation.
 ](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/installing/installing-on-bare-metal)
 
 ## Notes
-- Changing network configuration is done with the `setup-ovs.sh` file. 
+- Basic network configuration is set with the `init-interfaces.sh` file, which run via MCO files. MCO files are MachineConfig, which you can apply manually once the cluster is up or add it to the installation automation/pipeline. MachineConfig file is a "Day 2" tool that allows to configure or run scripts on a machine with an installed OS (post-installation).
 
-- In order to change the bond type to something other than balance-slb (for example active-backup) ,open the  `setup-ovs.sh` file and search for the “#make bond” section. 
-Change *“ovs-port.bond-mode”* to the desired type and make sure that all other related settings are aligned. 
-
-- MachineConfig file is a “Day 2” tool that allows to configure or run scripts on a machine with an installed OS (post-installation).
+- Bond configuration is set via kubernetes-nmstate manifests (TBD).
 
 ## CI and Testing
 This repo uses [coreos-assembler repo](https://github.com/coreos/coreos-assembler) to run important scenarios relevant to this use-case.
-The test downloads the latest RHCOS image and runs network related tests, using the local `setup-ovs.sh` script.
+The test downloads the latest RHCOS image and runs network related tests, checking the relevant scenarios used in this repo.
 You can run these tests manually on Fedora by running the test script:
 ```bash
 sudo ./tests/setup.sh

--- a/init-interfaces.sh
+++ b/init-interfaces.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -ex
+
+is_con_exists() {
+  local con_name=$1
+  if nmcli -t -g NAME con show | grep -w -q "$con_name"; then
+    return 0 # true
+  fi
+  return 1 # false
+}
+
+is_con_active() {
+  local con_name=$1
+  if nmcli -t -g NAME con show --active | grep -w -q "$con_name"; then
+    return 0 # true
+  fi
+  return 1 # false
+}
+
+get_con_name_by_device() {
+  local dev_name=$1
+  local con_name
+  con_name=$(nmcli -g GENERAL.CONNECTION dev show "$dev_name")
+  echo "$con_name"
+}
+
+generate_new_con_name() {
+  local device_name=$1
+  printf "ethernet-%s-%s" "$device_name" "$RANDOM"
+}
+
+if [[ ! -f /boot/mac_addresses ]] ; then
+  echo "no mac address configuration file found .. exiting"
+  exit 1
+fi
+
+primary_mac="$(awk -F= '/PRIMARY_MAC/ {print $2}' < /boot/mac_addresses | tr '[:upper:]' '[:lower:]')"
+secondary_mac="$(awk -F= '/SECONDARY_MAC/ {print $2}' < /boot/mac_addresses | tr '[:upper:]' '[:lower:]')"
+
+default_device=""
+secondary_device=""
+default_connection_name=""
+secondary_connection_name=""
+
+for dev in $(nmcli device status | awk '/ethernet/ {print $1}'); do
+  dev_mac=$(nmcli -g GENERAL.HWADDR dev show "$dev" | sed -e 's/\\//g' | tr '[:upper:]' '[:lower:]')
+  case $dev_mac in
+    $primary_mac)
+      default_device="$dev"
+      default_connection_name=$(get_con_name_by_device "$dev")
+      ;;
+    $secondary_mac)
+      secondary_device="$dev"
+      secondary_connection_name=$(get_con_name_by_device "$dev")
+      ;;
+    *)
+      ;;
+   esac
+done
+
+echo -e "default dev: $default_device (CONNECTION.NAME $default_connection_name)\nsecondary dev: $secondary_device (CONNECTION.NAME $secondary_connection_name)"
+if [[ -z "$default_device" ]] || [[ -z "$secondary_device" ]]; then
+  echo "error: primary/secondary device name not found"
+  exit 1
+fi
+
+if eval ! is_con_exists "\"$default_connection_name\""; then
+  default_connection_name="$(generate_new_con_name "$default_device")" && export default_connection_name
+  nmcli con add type ethernet \
+                conn.interface "$default_device" \
+                connection.autoconnect yes \
+                ipv4.method auto \
+                con-name "$default_connection_name"
+fi
+if eval ! is_con_active "\"$default_connection_name\""; then
+  nmcli con up "$default_connection_name"
+fi
+
+if eval ! is_con_exists "\"$secondary_connection_name\""; then
+  secondary_connection_name="$(generate_new_con_name "$secondary_device")" && export secondary_connection_name
+  nmcli con add type ethernet \
+                conn.interface "$secondary_device" \
+                connection.autoconnect no \
+                ipv4.method disabled \
+                con-name "$secondary_connection_name"
+fi
+if eval is_con_active "\"$secondary_connection_name\""; then
+  nmcli con down "$secondary_connection_name"
+fi

--- a/mco_ovs_supervisor.yml.tmpl
+++ b/mco_ovs_supervisor.yml.tmpl
@@ -10,15 +10,19 @@ spec:
       version: 3.1.0
     systemd:
       units:
+        - contents:
+          name: setup-ovs.service
+          enabled: false
         - contents: |
             [Unit]
-            After=NetworkManager.service openvswitch.service
+            Before=kubelet.service
+            After=NetworkManager.service
             [Service]
             Type=oneshot
-            ExecStart=/bin/sh /var/setup-ovs.sh
+            ExecStart=/bin/sh /var/init-interfaces.sh
             [Install]
             WantedBy=multi-user.target
-          name: setup-ovs.service
+          name: init-interfaces.service
           enabled: true
     storage:
       files:
@@ -26,4 +30,4 @@ spec:
             source: data:text/plain;charset=utf-8;base64,${base64_script_content}
           filesystem: root
           mode: 484
-          path: /var/setup-ovs.sh
+          path: /var/init-interfaces.sh

--- a/mco_ovs_workers.yml.tmpl
+++ b/mco_ovs_workers.yml.tmpl
@@ -10,15 +10,19 @@ spec:
       version: 3.1.0
     systemd:
       units:
+        - contents:
+          name: setup-ovs.service
+          enabled: false
         - contents: |
             [Unit]
-            After=NetworkManager.service openvswitch.service
+            Before=kubelet.service
+            After=NetworkManager.service
             [Service]
             Type=oneshot
-            ExecStart=/bin/sh /var/setup-ovs.sh
+            ExecStart=/bin/sh /var/init-interfaces.sh
             [Install]
             WantedBy=multi-user.target
-          name: setup-ovs.service
+          name: init-interfaces.service
           enabled: true
     storage:
       files:
@@ -26,4 +30,4 @@ spec:
             source: data:text/plain;charset=utf-8;base64,${base64_script_content}
           filesystem: root
           mode: 484
-          path: /var/setup-ovs.sh
+          path: /var/init-interfaces.sh

--- a/tests/network.go
+++ b/tests/network.go
@@ -15,6 +15,7 @@
 package misc
 
 import (
+	"encoding/base64"
 	"fmt"
 	"time"
 	"net"
@@ -37,6 +38,22 @@ func init() {
 		Platforms:   []string{"qemu-unpriv"},
 		Timeout:     20 * time.Minute,
 	})
+	register.RegisterTest(&register.Test{
+		Run:         InitInterfacesPreConfigured,
+		ClusterSize: 0,
+		Name:        "rhcos.network.init-interfaces-pre-configured",
+		Distros:     []string{"rhcos"},
+		Platforms:   []string{"qemu-unpriv"},
+		Timeout:     20 * time.Minute,
+	})
+	register.RegisterTest(&register.Test{
+		Run:         InitInterfacesNotConfigured,
+		ClusterSize: 0,
+		Name:        "rhcos.network.init-interfaces-not-configured",
+		Distros:     []string{"rhcos"},
+		Platforms:   []string{"qemu-unpriv"},
+		Timeout:     20 * time.Minute,
+	})
 }
 
 // NetworkSecondaryNics verifies that secondary NICs are created on the node
@@ -51,14 +68,193 @@ func NetworkSecondaryNics(c cluster.TestCluster) {
 	checkExpectedMACs(c, m, expectedMacsList)
 }
 
-func checkExpectedMACs(c cluster.TestCluster, m platform.Machine, expectedMacsList []string) {
-	connectionNamesList := getConnectionsList(c, m)
-	connectionDeviceMap, err := getConnectionDeviceMap(c, m, connectionNamesList)
+// InitInterfacesPreConfigured checks the scenario where the connections are already pre-configured so the script does
+// not configured anything
+// The test checks init-interfaces script on ignition context since MCO is not available on this test infra
+func InitInterfacesPreConfigured(c cluster.TestCluster) {
+	primaryMac := "52:55:00:d1:56:00"
+	secondaryMac := "52:55:00:d1:56:01"
+
+	setupWithInterfacesTest(c, primaryMac, secondaryMac)
+
+	m := c.Machines()[0]
+	macConnectionMap, err := getMacConnectionMap(c, m)
 	if err != nil {
-		c.Fatalf(fmt.Sprintf("failed to get connectionDeviceMap: %v", err))
+		c.Fatalf(fmt.Sprintf("failed to get macConnectionMap: %v", err))
+	}
+	err = checkExpectedInterfacesStatus(c, m, macConnectionMap, []string{primaryMac}, []string{secondaryMac})
+	if err != nil {
+		c.Fatalf(fmt.Sprintf("interfaces are not in expected status when connections are pre-configured: %v", err))
+	}
+}
+
+// InitInterfacesNotConfigured checks the scenario where the connections don't exist the script creates them
+// The test checks init-interfaces script on ignition context since MCO is not available on this test infra
+func InitInterfacesNotConfigured(c cluster.TestCluster) {
+	primaryMac := "52:55:00:d1:56:00"
+	secondaryMac := "52:55:00:d1:56:01"
+
+	setupWithInterfacesTest(c, primaryMac, secondaryMac)
+	m := c.Machines()[0]
+	simulateNoConnections(c, m, []string{primaryMac, secondaryMac})
+
+	macConnectionMap, err := getMacConnectionMap(c, m)
+	if err != nil {
+		c.Fatalf(fmt.Sprintf("failed to get macConnectionMap: %v", err))
+	}
+	err = checkExpectedInterfacesStatus(c, m, macConnectionMap, []string{primaryMac}, []string{secondaryMac})
+	if err != nil {
+		c.Fatalf(fmt.Sprintf("interfaces are not in expected status when connections do not exist: %v", err))
+	}
+}
+
+func simulateNoConnections(c cluster.TestCluster, m platform.Machine, macConnectionsToDelete []string) {
+	macConnectionMap, err := getMacConnectionMap(c, m)
+	if err != nil {
+		c.Fatalf(fmt.Sprintf("failed to get macConnectionMap: %v", err))
 	}
 
-	macConnectionMap, err := getMacConnectionMap(c, m, connectionNamesList, connectionDeviceMap)
+	removeConnectionsByMac(c, m, macConnectionMap, macConnectionsToDelete)
+	err = m.Reboot()
+	if err != nil {
+		c.Fatalf("failed to reboot the machine: %v", err)
+	}
+}
+
+func setupWithInterfacesTest(c cluster.TestCluster, primaryMac, secondaryMac string) {
+	interfacesScript, err := getInterfacesScript()
+	if err != nil {
+		c.Fatalf("failed to read interfaces Script: %v", err)
+	}
+
+	captureMacsScript, err := getCaptureMacsScript()
+	if err != nil {
+		c.Fatalf("failed to read interfaces Script: %v", err)
+	}
+
+	var userdata *conf.UserData = conf.Ignition(fmt.Sprintf(`{
+		"ignition": {
+			"version": "3.2.0"
+		},
+		"storage": {
+			"files": [
+				{
+					"path": "/usr/local/bin/capture-macs",
+					"contents": { "source": "data:text/plain;base64,%s" },
+					"mode": 755
+				},
+				{
+					"path": "/usr/local/bin/init-interfaces.sh",
+					"contents": { "source": "data:text/plain;base64,%s" },
+					"mode": 755
+				}
+			]
+		},
+		"systemd": {
+			"units": [
+				{
+					"contents": "[Unit]\nDescription=Capture MAC address from kargs\nBefore=coreos-installer.target\nAfter=coreos-installer.service\n\nConditionKernelCommandLine=macAddressList\nRequiresMountsFor=/boot\n\n[Service]\nType=oneshot\nMountFlags=slave\nExecStart=/usr/local/bin/capture-macs\n\n[Install]\nRequiredBy=multi-user.target\n",
+					"enabled": true,
+					"name": "capture-macs.service"
+				},
+				{
+					"contents": "[Unit]\nDescription=Initialize Interfaces\nBefore=kubelet.service\nAfter=NetworkManager.service\nAfter=capture-macs.service\n\n\n[Service]\nType=oneshot\nExecStart=/usr/local/bin/init-interfaces.sh\n\n[Install]\nRequiredBy=multi-user.target\n",
+					"enabled": true,
+					"name": "init-interfaces.service"
+				}
+			]
+		}
+	}`,
+		base64.StdEncoding.EncodeToString([]byte(captureMacsScript)),
+		base64.StdEncoding.EncodeToString([]byte(interfacesScript))))
+
+	options := platform.QemuMachineOptions{
+		SecondaryNics: 2,
+	}
+
+	var m platform.Machine
+	switch pc := c.Cluster.(type) {
+	// These cases have to be separated because when put together to the same case statement
+	// the golang compiler no longer checks that the individual types in the case have the
+	// NewMachineWithQemuOptions function, but rather whether platform.Cluster
+	// does which fails
+	case *unprivqemu.Cluster:
+		m, err = pc.NewMachineWithQemuOptions(userdata, options)
+	default:
+		panic("unreachable")
+	}
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	// Add karg needed for the ignition to configure the network properly.
+	addKernelArgs(c, m, []string{fmt.Sprintf("macAddressList=%s,%s", primaryMac, secondaryMac)})
+}
+
+func getInterfacesScript() (string, error) {
+	path := "init-interfaces.sh"
+
+	var data, err = os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func getCaptureMacsScript() (string, error) {
+	path := "capture-macs.sh"
+
+	var data, err = os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func removeConnectionsByMac(c cluster.TestCluster, m platform.Machine, macConnectionMap map[string]string, macsList[]string) {
+	for _, mac := range macsList {
+		connectionToDelete := macConnectionMap[mac]
+		c.MustSSH(m, fmt.Sprintf("sudo nmcli con del '%s'", connectionToDelete))
+	}
+}
+
+func checkExpectedInterfacesStatus(c cluster.TestCluster, m platform.Machine, macConnectionMap map[string]string, expectedUpInterfacesMacList, expectedDownInterfacesMacList []string) error {
+	failedConnections := []string{}
+	for _, ifaceMac := range expectedUpInterfacesMacList {
+		connectionName := macConnectionMap[ifaceMac]
+		if !isConnectionUp(c, m, connectionName) {
+			failedConnections = append(failedConnections, fmt.Sprintf("expected connection %s to be UP", connectionName))
+		}
+	}
+
+	for _, ifaceMac := range expectedDownInterfacesMacList {
+		connectionName := macConnectionMap[ifaceMac]
+		if isConnectionUp(c, m, connectionName) {
+			failedConnections = append(failedConnections, fmt.Sprintf("expected connection %s to be DOWN", connectionName))
+		}
+	}
+
+	if len(failedConnections) != 0 {
+		return fmt.Errorf(strings.Join(failedConnections, ","))
+	}
+	return nil
+}
+
+func isConnectionUp(c cluster.TestCluster, m platform.Machine, connectionName string) bool {
+	if getConnectionStatus(c, m, connectionName) != "activated" {
+		return false
+	}
+	return true
+}
+
+func getConnectionStatus(c cluster.TestCluster, m platform.Machine, connectionName string) string {
+	return string(c.MustSSH(m, fmt.Sprintf("nmcli -f GENERAL.STATE con show '%s' | awk '{print $2}'", connectionName)))
+}
+
+func checkExpectedMACs(c cluster.TestCluster, m platform.Machine, expectedMacsList []string) {
+	macConnectionMap, err := getMacConnectionMap(c, m)
 	if err != nil {
 		c.Fatalf(fmt.Sprintf("failed to get macConnectionMap: %v", err))
 	}
@@ -81,12 +277,18 @@ func getConnectionDeviceMap(c cluster.TestCluster, m platform.Machine, connectio
 }
 
 func getConnectionsList(c cluster.TestCluster, m platform.Machine) []string {
-	output := string(c.MustSSH(m, "nmcli -t -f NAME con show --active"))
+	output := string(c.MustSSH(m, "nmcli -t -f NAME con show"))
 	interfaceNames := strings.Split(output, "\n")
 	return interfaceNames
 }
 
-func getMacConnectionMap(c cluster.TestCluster, m platform.Machine, connectionNamesList []string, connectionDeviceMap map[string]string) (map[string]string, error) {
+func getMacConnectionMap(c cluster.TestCluster, m platform.Machine) (map[string]string, error) {
+	connectionNamesList := getConnectionsList(c, m)
+	connectionDeviceMap, err := getConnectionDeviceMap(c, m, connectionNamesList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get connectionDeviceMap: %v", err)
+	}
+
 	MacInterfaceMap := map[string]string{}
 	for _, connection := range connectionNamesList {
 		interfaceMACAddress, err := getDeviceMAC(c, m, connectionDeviceMap[connection])


### PR DESCRIPTION
This PR introduces a script that will be run by MCO, and will configure the basic networking needed for future kuberenetes-nmstate manifest deployment.