### PR TITLE
[simplify-networking] Detach captured macs from ignition

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ macAddressList | String | List of MAC address should be set per host In the foll
 
 
 ### 2. Prepare the files
+- Base64 encode the `capture-macs.sh` file and paste the content into custom-config.fcc file into "base64_capture_macs_script_content" section. 
+
+    **TIP:** To update the content you can use:
+
+```
+export base64_capture_macs_script_content=$(cat capture-macs.sh|base64 -w 0) && envsubst <  custom-config.fcc.tmpl > custom-config.fcc
+```
+
 - Create the ign file from the custom-config.fcc: 
 ```
 fcct custom-config.fcc > file.ign

--- a/capture-macs.sh
+++ b/capture-macs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Processing MAC addresses"
+cmdline=( $(</proc/cmdline) )
+karg() {
+		local name="$1" value="${2:-}"
+		for arg in "${cmdline[@]}"; do
+				if [[ "${arg%%=*}" == "${name}" ]]; then
+						value="${arg#*=}"
+				fi
+		done
+		echo "${value}"
+}
+# Wait for device nodes
+udevadm settle
+
+macs="$(karg macAddressList)"
+if [[ -z $macs ]]; then
+	echo "No MAC addresses specified."
+	exit 1
+fi
+
+export PRIMARY_MAC=$(echo $macs | awk -F, '{print $1}')
+export SECONDARY_MAC=$(echo $macs | awk -F, '{print $2}')
+mount "/dev/disk/by-label/boot" /boot
+echo -e "PRIMARY_MAC=${PRIMARY_MAC}\nSECONDARY_MAC=${SECONDARY_MAC}" > /boot/mac_addresses

--- a/custom-config.fcc.tmpl
+++ b/custom-config.fcc.tmpl
@@ -20,33 +20,7 @@ storage:
     - path: /usr/local/bin/capture-macs
       mode: 0755
       contents:
-        inline: |
-          #!/usr/bin/env bash
-          set -ex
-          echo "Processing MAC addresses"
-          cmdline=( $(</proc/cmdline) )
-          karg() {
-              local name="$1" value="${2:-}"
-              for arg in "${cmdline[@]}"; do
-                  if [[ "${arg%%=*}" == "${name}" ]]; then
-                      value="${arg#*=}"
-                  fi
-              done
-              echo "${value}"
-          }
-          # Wait for device nodes
-          udevadm settle
-          
-          macs="$(karg macAddressList)"
-          if [[ -z $macs ]]; then
-            echo "No MAC addresses specified."
-            exit 1
-          fi
-          export PRIMARY_MAC=$(echo $macs | awk -F, '{print $1}')
-          export SECONDARY_MAC=$(echo $macs | awk -F, '{print $2}')
-          mount "/dev/disk/by-label/boot" /boot
-          echo -e "PRIMARY_MAC=${PRIMARY_MAC}\nSECONDARY_MAC=${SECONDARY_MAC}" > /boot/mac_addresses
-         
+        source: data:text/plain;charset=utf-8;base64,${base64_capture_macs_script_content}
     - path: /usr/local/bin/create-datastore
       mode: 0755
       contents:

--- a/tests/test-coreos.sh
+++ b/tests/test-coreos.sh
@@ -63,12 +63,21 @@ modify_ignition_fcc() {
   local rhcos_slb_repo_path=$1
   local coreos_ci_repo_path=$2
   local coreos_ci_ignition_relative_path=$3
-  local rhcos_slb_ignition_fcc=${rhcos_slb_repo_path}/custom-config.fcc
+  local rhcos_slb_capture_macs_script=${rhcos_slb_repo_path}/capture-macs.sh
+  local coreos_ci_capture_macs_script=${coreos_ci_repo_path}/mantle/capture-macs.sh
+  local rhcos_slb_ignition_fcc_tmpl=${rhcos_slb_repo_path}/custom-config.fcc.tmpl
+  local coreos_ci_ignition_fcc_tmpl=${coreos_ci_repo_path}/custom-config.fcc.tmpl
   local coreos_ci_ignition_fcc=${coreos_ci_repo_path}/custom-config.fcc
   local coreos_ci_ignition_ign=${coreos_ci_repo_path}/${coreos_ci_ignition_relative_path}/custom-config.ign
 
+  # Copy capture-macs.sh to coreos-ci mantle folder
+  cp ${rhcos_slb_capture_macs_script} ${coreos_ci_capture_macs_script}
+
   # Copy ignition_fcc to coreos-ci folder
-  cp ${rhcos_slb_ignition_fcc} ${coreos_ci_ignition_fcc}
+  cp ${rhcos_slb_ignition_fcc_tmpl} ${coreos_ci_ignition_fcc_tmpl}
+
+  # Inject capture-macs script to ignition_fcc_tmpl and save it to ignition_fcc file
+  export base64_capture_macs_script_content=$(cat ${coreos_ci_capture_macs_script} | base64 -w 0) && envsubst < ${coreos_ci_ignition_fcc_tmpl} > ${coreos_ci_ignition_fcc}
 
   # Remove the exit fail if macs file in not in place, since kargs are added only after second reboot.
   sed -i 's|exit 1|exit 0|g' ${coreos_ci_ignition_fcc}


### PR DESCRIPTION
Currently the captured-macs is hard coded to the ignition file.
This makes it annoying to test separately from the ignition file.
Detaching the script from ignition.
Renaming the ignition to .tmpl
Refactoring the README to guide how to create the fcc from the
fcc.tmpl file.
Adjusting the ci to do the same.
