### PR TITLE
[simplify-networking] tests, Increase ci test timeout

### DIFF
--- a/tests/network.go
+++ b/tests/network.go
@@ -16,6 +16,7 @@ package misc
 
 import (
 	"fmt"
+	"time"
 	"net"
 	"os"
 	"strings"
@@ -34,6 +35,7 @@ func init() {
 		Name:        "rhcos.network.multiple-nics",
 		Distros:     []string{"rhcos"},
 		Platforms:   []string{"qemu-unpriv"},
+		Timeout:     20 * time.Minute,
 	})
 }
 


### PR DESCRIPTION
Recently gitActions takes 10 times longer per test (~10 minutes)
Increasing the timeout to 20 minutes.