### PR TITLE
[simplify-networking] Use kubernetes-nmstate to configure OVS SLB bond

### DIFF
--- a/add-slb-nncp.yaml
+++ b/add-slb-nncp.yaml
@@ -1,0 +1,33 @@
+apiVersion: nmstate.io/v1                                                       
+kind: NodeNetworkConfigurationPolicy                                            
+metadata:                                                                       
+  name: slb
+spec:
+  capture:
+    primary-nic: interfaces.description == "primary"
+    secondary-nic: interfaces.description == "secondary"
+  desiredState:
+    interfaces:
+    - name: brcnv-iface
+      type: ovs-interface
+      state: up
+      mac-address: "{{ capture.primary-nic.interfaces.0.mac-address }}"
+      ipv4:
+        enabled: true
+        dhcp: true
+    - name: brcnv
+      type: ovs-bridge
+      state: up
+      bridge:
+        options:
+          stp: false
+          mcast-snooping-enable: false
+          rstp: false
+        port:
+        - name: bond0
+          link-aggregation:
+            mode: balance-slb
+            port:
+            - name: "{{ capture.primary-nic.interfaces.0.name }}"
+            - name: "{{ capture.secondary-nic.interfaces.0.name }}"
+        - name: brcnv-iface

--- a/del-slb-nncp.yaml
+++ b/del-slb-nncp.yaml
@@ -1,0 +1,27 @@
+apiVersion: nmstate.io/v1                                                       
+kind: NodeNetworkConfigurationPolicy                                            
+metadata:                                                                       
+  name: slb
+spec:
+  capture:
+    primary-nic: interfaces.description == "primary"
+    secondary-nic: interfaces.description == "secondary"
+  desiredState:
+    interfaces:
+    - name: brcnv-iface
+      type: ovs-interface
+      state: absent
+    - name: brcnv
+      type: ovs-bridge
+      state: absent
+    - name: "{{ capture.primary-nic.interfaces.0.name }}"
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: true
+        dhcp: true
+    - name: "{{ capture.secondary-nic.interfaces.0.name }}"
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: false

--- a/kcli/README.md
+++ b/kcli/README.md
@@ -20,10 +20,20 @@ init cmdline to specify `custom-config` with mac addresses, and apply patched
 ignition (it disable create-datastore and remove systemd dependencies at 
 capture-macs.sh unit) and the machince config with the OVS bridge setup.
 
+Start the cluster
 ```bash
 ./kcli/run.sh ./kcli/ocp.yaml openshift-pull.json
 ```
 
+Configure the bond with kubernetes-nmstate
+```bash
+./kcli/add-slb.sh
+```
+
+Remove the bond with kubernetes-nmstate
+```bash
+./kcli/del-slb.sh
+```
 
 ### Start a RHCOS 4.10 image with ignition
 

--- a/kcli/add-slb.sh
+++ b/kcli/add-slb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash 
+
+set -xe
+
+oc apply -f add-slb-nncp.yaml
+./kcli/update-keepalived.sh brcnv-iface
+./kcli/retry.sh oc wait nncp slb --for=condition=Available

--- a/kcli/del-slb.sh
+++ b/kcli/del-slb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash 
+
+set -xe
+
+oc apply -f del-slb-nncp.yaml
+./kcli/update-keepalived.sh enx525400f68001
+./kcli/retry.sh oc wait nncp slb --for=condition=Available

--- a/kcli/deploy-knmstate.sh
+++ b/kcli/deploy-knmstate.sh
@@ -1,0 +1,42 @@
+#/bin/bash -e
+
+knmstate_version=v0.64.4
+
+oc apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$knmstate_version/nmstate.io_nmstates.yaml
+oc apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$knmstate_version/namespace.yaml
+oc apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$knmstate_version/service_account.yaml
+oc apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$knmstate_version/role.yaml
+oc apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$knmstate_version/role_binding.yaml
+oc apply -f https://github.com/nmstate/kubernetes-nmstate/releases/download/$knmstate_version/operator.yaml
+
+cat <<EOF | kubectl apply -f -
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+ name: nmstate
+allowPrivilegedContainer: true
+allowHostDirVolumePlugin: true
+allowHostNetwork: true
+allowHostIPC: false
+allowHostPID: false
+allowHostPorts: false
+readOnlyRootFilesystem: false
+runAsUser:
+ type: RunAsAny
+seLinuxContext:
+ type: RunAsAny
+users:
+- system:serviceaccount:nmstate:nmstate-handler
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: nmstate.io/v1
+kind: NMState
+metadata:
+  name: nmstate
+EOF
+
+sleep 30
+
+oc rollout status -w -n nmstate ds nmstate-handler
+oc rollout status -w -n nmstate deployment nmstate-webhook

--- a/kcli/ocp.yaml
+++ b/kcli/ocp.yaml
@@ -29,3 +29,5 @@ rhocs-slb:
  workers: 1
  memory: 16384
  numcpus: 16
+ postscripts:
+   - kcli/deploy-knmstate.sh

--- a/kcli/retry.sh
+++ b/kcli/retry.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -xe
+
+n=0
+until [ "$n" -ge 5 ]
+do
+   $@ && break
+   n=$((n+1)) 
+done

--- a/kcli/update-keepalived.sh
+++ b/kcli/update-keepalived.sh
@@ -1,0 +1,10 @@
+#!/bin/bash 
+
+set -xe
+
+interface=$1
+
+# At kcli a VIP is used to expose apiserver we should change keepalive to put the VIP at the new ovs-interface
+kcli ssh rhocs-slb-master-0 -- "sudo sed -i 's@interface .*@interface $interface@' /etc/kubernetes/keepalived.conf"
+pod_id=$(kcli ssh rhocs-slb-master-0 -- "sudo crictl pods --namespace openshift-infra --name keepalived-rhocs-slb-master-0.redhat.com --output json |jq -r .items[0].id")
+kcli ssh rhocs-slb-master-0 -- "sudo crictl rmp --force $pod_id"


### PR DESCRIPTION
This PR add the final part to configure the OVS SLB using kubernetes-nmstate it also contains needed integration with kcli so it can be tested.