### PR TITLE
nncp: Keep the brcnv name for the ovs-interface

### DIFF
--- a/add-slb-nncp.yaml
+++ b/add-slb-nncp.yaml
@@ -8,7 +8,7 @@ spec:
     secondary-nic: interfaces.description == "secondary"
   desiredState:
     interfaces:
-    - name: brcnv-iface
+    - name: brcnv
       type: ovs-interface
       state: up
       mac-address: "{{ capture.primary-nic.interfaces.0.mac-address }}"
@@ -30,4 +30,4 @@ spec:
             port:
             - name: "{{ capture.primary-nic.interfaces.0.name }}"
             - name: "{{ capture.secondary-nic.interfaces.0.name }}"
-        - name: brcnv-iface
+        - name: brcnv

--- a/del-slb-nncp.yaml
+++ b/del-slb-nncp.yaml
@@ -8,7 +8,7 @@ spec:
     secondary-nic: interfaces.description == "secondary"
   desiredState:
     interfaces:
-    - name: brcnv-iface
+    - name: brcnv
       type: ovs-interface
       state: absent
     - name: brcnv

--- a/kcli/add-slb.sh
+++ b/kcli/add-slb.sh
@@ -3,5 +3,5 @@
 set -xe
 
 oc apply -f add-slb-nncp.yaml
-./kcli/update-keepalived.sh brcnv-iface
+./kcli/update-keepalived.sh brcnv
 ./kcli/retry.sh oc wait nncp slb --for=condition=Available


### PR DESCRIPTION
When the NNCP is applied towards a cluster configured with the previous
script the NNCP fails since the ovs-interface was named brcnv and at the
NNCP is brcnv-iface. This change keep the brcnv name to the
ovs-interface since nmstate supports interfaces with same name.