### PR TITLE
Keep the old name of the service

### DIFF
--- a/mco_ovs_supervisor.yml.tmpl
+++ b/mco_ovs_supervisor.yml.tmpl
@@ -10,9 +10,6 @@ spec:
       version: 3.1.0
     systemd:
       units:
-        - contents:
-          name: setup-ovs.service
-          enabled: false
         - contents: |
             [Unit]
             Before=kubelet.service
@@ -22,7 +19,7 @@ spec:
             ExecStart=/bin/sh /var/init-interfaces.sh
             [Install]
             WantedBy=multi-user.target
-          name: init-interfaces.service
+          name: setup-ovs.service
           enabled: true
     storage:
       files:

--- a/mco_ovs_workers.yml.tmpl
+++ b/mco_ovs_workers.yml.tmpl
@@ -10,9 +10,6 @@ spec:
       version: 3.1.0
     systemd:
       units:
-        - contents:
-          name: setup-ovs.service
-          enabled: false
         - contents: |
             [Unit]
             Before=kubelet.service
@@ -22,7 +19,7 @@ spec:
             ExecStart=/bin/sh /var/init-interfaces.sh
             [Install]
             WantedBy=multi-user.target
-          name: init-interfaces.service
+          name: setup-ovs.service
           enabled: true
     storage:
       files:

--- a/tests/network.go
+++ b/tests/network.go
@@ -160,7 +160,7 @@ func setupWithInterfacesTest(c cluster.TestCluster, primaryMac, secondaryMac str
 				{
 					"contents": "[Unit]\nDescription=Initialize Interfaces\nBefore=kubelet.service\nAfter=NetworkManager.service\nAfter=capture-macs.service\n\n\n[Service]\nType=oneshot\nExecStart=/usr/local/bin/init-interfaces.sh\n\n[Install]\nRequiredBy=multi-user.target\n",
 					"enabled": true,
-					"name": "init-interfaces.service"
+					"name": "setup-ovs.service"
 				}
 			]
 		}


### PR DESCRIPTION
Due to the renaming of setup-ovs.service to init-interfaces.service,
newly installed clusters fail with the following:

  Failed to disable unit: Unit file setup-ovs.service does not exist.

That is due to us trying to disable a service that was never installed
as a unit file.

This patch works around it by keeping the old service name.

Signed-off-by: Petr Horáček <phoracek@redhat.com>