### PR TITLE
init-interfaces: Enforce MAC address

### DIFF
--- a/init-interfaces.sh
+++ b/init-interfaces.sh
@@ -100,7 +100,8 @@ if eval ! is_con_exists "\"$default_connection_name\""; then
                 conn.interface "$default_device" \
                 connection.autoconnect yes \
                 ipv4.method auto \
-                con-name "$default_connection_name"
+                con-name "$default_connection_name" \
+                802-3-ethernet.mac-address $primary_mac
 fi
 if eval ! is_con_active "\"$default_connection_name\""; then
   nmcli con up "$default_connection_name"
@@ -113,7 +114,8 @@ if eval ! is_con_exists "\"$secondary_connection_name\""; then
                 connection.autoconnect yes \
                 ipv4.method disabled \
                 ipv6.method disabled \
-                con-name "$secondary_connection_name"
+                con-name "$secondary_connection_name" \
+                802-3-ethernet.mac-address $secondary_mac
 fi
 if eval ! is_con_active "\"$secondary_connection_name\""; then
   nmcli con up "$secondary_connection_name"


### PR DESCRIPTION
To be sure that the MAC address is present at the keyfile this file
enforce it when interface is set up.

From the reverted commit [1]

[1] https://github.com/RHsyseng/rhcos-slb/commit/ef360ae6d1fc11562c074a1c270766edfe7f5fe1#diff-0c94eb0760c378a3b22ac5f205d9b3312b528ff954fe82d077a897f5fec9b06cR107

Signed-off-by: Enrique Llorente <ellorent@redhat.com>