### PR TITLE
Update init-interfaces.sh

### DIFF
--- a/init-interfaces.sh
+++ b/init-interfaces.sh
@@ -118,7 +118,7 @@ if eval ! is_con_exists "\"$secondary_connection_name\""; then
                 802-3-ethernet.mac-address $secondary_mac
 fi
 if eval ! is_con_active "\"$secondary_connection_name\""; then
-  nmcli con up "$secondary_connection_name"
+  nmcli con up "$secondary_connection_name" || /bin/true
 fi
 
 set_description "$primary_mac" "$default_device" primary


### PR DESCRIPTION
Do not abort if the 2nd connection fails, 
In our GS environment we have one of bond interfaces disconnected, and the script will fail on this line, and abort, which failed to set the description on the connection.