### PR TITLE
ci, Bump go version to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.18
 
       - name: Run the test
         run: ARTIFACTS=~/test_artifacts COSA_NO_KVM=yes ./tests/test-coreos.sh

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -4,7 +4,7 @@ set -ex
 
 install_go() {
 	destination=/usr/local
-	version=1.16.8
+	version=1.18.7
 	tarball=go$version.linux-amd64.tar.gz
 	url=https://dl.google.com/go/
 


### PR DESCRIPTION
Current CI on coreos/coreos-assembler demands go version >=1.17. Updating CI and scripts accordingly.
