### PR TITLE
ci, Add weekely CI Test

### DIFF
--- a/.github/workflows/weeklyci.yml
+++ b/.github/workflows/weeklyci.yml
@@ -1,0 +1,31 @@
+name: [simplify-networking] Weekly CI Test
+
+on:
+  schedule:
+    - cron '0 12 * * 1'
+
+  workflow_dispatch:
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: simplify-networking
+      - name: Set up dependencies
+        run: |
+          sudo add-apt-repository ppa:smoser/swtpm
+          sudo apt-get update
+          sudo apt-get install qemu qemu-system-x86 qemu-utils npm swtpm
+          sudo npm i -D tap-junit
+      - name: Run the test
+        run: ARTIFACTS=~/test_artifacts COSA_NO_KVM=yes ./tests/test-coreos.sh
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: ~/test_artifacts
+          retention-days: 5


### PR DESCRIPTION
In order to prevent CI to broken by third party dependants like coreos-coreos-assembler repo, adding a weekly ci check.

Signed-off-by: Ram Lavi <ralavi@redhat.com>