### PR TITLE
fix typo in weeklyci

### DIFF
--- a/.github/workflows/weeklyci.yml
+++ b/.github/workflows/weeklyci.yml
@@ -1,8 +1,8 @@
-name: [simplify-networking] Weekly CI Test
+name: '[simplify-networking] - Weekly CI Test'
 
 on:
   schedule:
-    - cron '0 12 * * 1'
+    - cron: '0 12 * * 1'
 
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
This Pr fixes a typo in the cron job parameters and project name

Signed-off-by: Ram Lavi <ralavi@redhat.com>