### PR TITLE
Make sure the interface match our expected state

### DIFF
--- a/init-interfaces.sh
+++ b/init-interfaces.sh
@@ -120,6 +120,12 @@ if eval ! is_con_exists "\"$secondary_connection_name\""; then
                 802-3-ethernet.mac-address "${secondary_mac}"
 fi
 if eval ! is_con_active "\"${secondary_connection_name}\""; then
+  nmcli con mod "${secondary_connection_name}" \
+                connection.interface-name "${secondary_device}" \
+                connection.autoconnect yes \
+                ipv4.method disabled \
+                ipv6.method disabled \
+                802-3-ethernet.mac-address "${secondary_mac}"
   nmcli con up "${secondary_connection_name}" || /bin/true
 fi
 


### PR DESCRIPTION
When the secondary connection exists but not activated, Adding command to make sure that the parameters of the connections are as expected.