### PR TITLE
[simplify-networking] ci, swtpm: Pin to a supported version ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up dependencies
         run: |
-          sudo add-apt-repository ppa:smoser/swtpm
           sudo apt-get update
           sudo apt-get install qemu qemu-system-x86 qemu-utils npm swtpm
           sudo npm i -D tap-junit


### PR DESCRIPTION
One of the dependencies in the gitActions workflows is swtpm. As ubuntu-latest recently moved to 22.04 [0], it is now not complient with the swtpm supported ubuntu vertions [1].
Pinning to a supportd version ubuntu 20.04.

[0] https://github.com/actions/runner-images/pull/6776 
[1] https://launchpad.net/~smoser/+archive/ubuntu/swtpm

Signed-off-by: Ram Lavi <ralavi@redhat.com>