### PR TITLE
[main] weeklyci, ci, swtpm: Pin workflow to ubuntu 20.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/weeklyci.yml
+++ b/.github/workflows/weeklyci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
One of the dependencies in the gitActions workflows is swtpm. As ubuntu-latest recently moved to 22.04 [0], it is now not complient with the swtpm supported ubuntu vertions [1].
Pinning to a supportd version ubuntu 20.04.

[0] actions/runner-images#6776
[1] https://launchpad.net/~smoser/+archive/ubuntu/swtpm

Signed-off-by: Ram Lavi <ralavi@redhat.com>