### PR TITLE
Drop smoser/swtpm ppa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Set up dependencies
         run: |
-          sudo add-apt-repository ppa:smoser/swtpm
           sudo apt-get update
           sudo apt-get install qemu qemu-system-x86 qemu-utils npm swtpm
           sudo npm i -D tap-junit


### PR DESCRIPTION
As it is, the versions in jammy are newer than the versions in the
PPA, so on 22.04 you *should* use the packages in jammy.