### PR TITLE
[simplify-networking] - ci, swtpm: Pin to a supported version ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The CI is currently running with the latest ubuntu version (22.04) The latter does not support the use the swtpm package currently used. In order to allow the CI to work, temporarilly downgrading the ubuntu version to the former one 20.04.
This does not affect the actual CI testing as they are run on the RHCOS VM.