### PR TITLE
Add match to 99-default

### DIFF
--- a/custom-config.fcc.tmpl
+++ b/custom-config.fcc.tmpl
@@ -7,6 +7,8 @@ storage:
       mode: 420
       contents:
         inline: |
+          [Match]
+          OriginalName=*
           [Link]
           NamePolicy=mac
           MACAddressPolicy=persistent


### PR DESCRIPTION
For ocp >= 4.13 is mandatory to have a Match section at NetworkManager confing with Link.

Error 
```
 localhost systemd-udevd[1441]: /etc/systemd/network/99-default.link: No valid settings found in the [Match] section, ignoring file. To match all interfaces, add OriginalName=* in the [Match] section
```

Looking at the systemd man page looks like the change is legit https://www.freedesktop.org/software/systemd/man/systemd.link.html

```
Example 1. /usr/lib/systemd/network/99-default.link

The link file 99-default.link that is shipped with systemd defines the default policies for the interface name, alternative names, and MAC address of links.

[Match]
OriginalName=*

[Link]
NamePolicy=keep kernel database onboard slot path
AlternativeNamesPolicy=database onboard slot path
MACAddressPolicy=persistent

```