### PR TITLE
Destroy br-ex to force ovs-configuration

### DIFF
--- a/init-interfaces.sh
+++ b/init-interfaces.sh
@@ -13,7 +13,7 @@ read_mac() {
 
 find_interface_by_mac() {
   local mac=$1
-  nmstatectl show --json |jq -r ".interfaces[] | select(.\"mac-address\"==\"$mac\").name"
+  nmstatectl show --json |jq -r ".interfaces[] | select(.\"mac-address\"==\"$mac\") | select(.\"type\"==\"ethernet\").name"
 }
 
 create_cnvnet() {
@@ -50,6 +50,12 @@ create_bondcnv() {
 # [2] https://github.com/openshift/machine-config-operator/pull/4212
   nmstatectl apply << EOF
 interfaces:
+- name: br-ex
+  type: ovs-interface
+  state: absent
+- name: br-ex
+  type: ovs-bridge
+  state: absent
 - name: bondcnv
   type: bond
   state: up


### PR DESCRIPTION
Some of the scenarios is a node with ovn-kubernetes already running but without using the bond, this change remove br-ex as part of bond creation so ovs-configuration.service will kick in and re-construct it on top of the bond.